### PR TITLE
add set_poolSize method

### DIFF
--- a/anticaptchaofficial/antinetworking.py
+++ b/anticaptchaofficial/antinetworking.py
@@ -1,4 +1,5 @@
 import requests
+from requests.adapters import HTTPAdapter
 import json
 import urllib3
 from datetime import datetime
@@ -218,3 +219,10 @@ class antiNetworking:
 
     def set_comment(self, value):
         self.comment = value
+
+    def set_poolSize(self, pool_connections, pool_maxsize=100):
+        adapter = HTTPAdapter(
+            pool_connections=pool_connections,
+            pool_maxsize=pool_maxsize
+        )
+        session.mount("https://", adapter)


### PR DESCRIPTION
This allow the user to configure the size of connection pool in requests library fixing the error: 
`WARNING:urllib3.connectionpool:Connection pool is full, discarding connection: api.anti-captcha.com. Connection pool size: 10`